### PR TITLE
Fix a issue in BundlePlugin

### DIFF
--- a/Android/DevSample/buildSrc/src/main/groovy/net/wequick/gradle/BundlePlugin.groovy
+++ b/Android/DevSample/buildSrc/src/main/groovy/net/wequick/gradle/BundlePlugin.groovy
@@ -83,6 +83,11 @@ abstract class BundlePlugin extends AndroidPlugin {
         def p = sp.projectDir
         def t = sp.taskNames[0]
         def pn = null
+
+        if (t == null) { // Nothing to do
+            return false
+        }
+
         if (p == null) {
             if (t.startsWith(':')) {
                 // gradlew :app.main:assembleRelease


### PR DESCRIPTION
When I do `gradle` in `Small/Android/DevSample`, I get a message:


```bsah
FAILURE: Build failed with an exception.

* Where:
Build file '/xxxx/Small/Android/DevSample/build.gradle' line: 24

* What went wrong:
A problem occurred evaluating root project 'DevSample'.
> Failed to apply plugin [class 'net.wequick.gradle.AppPlugin']
   > Cannot invoke method startsWith() on null object

```

It'll throw `java.lang.NullPointerException` from `BundlePlugin` if we don't specified the gradle task, so I did something to fix.

And it works:

```bash
Welcome to Gradle 2.6.

To run a build, run gradle <task> ...

To see a list of available tasks, run gradle tasks

To see a list of command-line options, run gradle --help

To see more detail about a task, run gradle help --task <task>

BUILD SUCCESSFUL
```