### PR TITLE
fix:wirte wrong manifest file when processDebugManifest

### DIFF
--- a/Android/DevSample/buildSrc/src/main/groovy/net/wequick/gradle/AppPlugin.groovy
+++ b/Android/DevSample/buildSrc/src/main/groovy/net/wequick/gradle/AppPlugin.groovy
@@ -199,7 +199,7 @@ class AppPlugin extends BundlePlugin {
                             if (k > 0) {
                                 filtered = true
                                 def k_ = line.indexOf('"', k + 15) // bypass 'android:name='
-                                line = line.substring(0, k) + line.substring(k_)
+                                line = line.substring(0, k) + line.substring(k_ + 1)
                             }
                             break
                         }


### PR DESCRIPTION
if **lib.*** has `android:name` in AndroidManifest.xml,configureDebugVariant overwrite wrong file
``` xml
//original file
<application android:name="com.xx.lib.base.App" >
    </application>

//after overwrite
<application " >
    </application>
```