### PR TITLE
fixed crash bug on phone which is installed xposed.

### DIFF
--- a/Android/DevSample/small/src/main/java/net/wequick/small/util/ReflectAccelerator.java
+++ b/Android/DevSample/small/src/main/java/net/wequick/small/util/ReflectAccelerator.java
@@ -28,6 +28,7 @@ import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
+import android.text.TextUtils;
 import android.util.DisplayMetrics;
 
 import java.io.File;
@@ -422,6 +423,14 @@ public class ReflectAccelerator {
     public static Resources newResources(Class resourcesClass, AssetManager assets,
                                          DisplayMetrics metrics, Configuration configuration) {
         try {
+            //if the phone has installed xposed,here will crash.
+            //because the resourcesClass is XResources.class,it's constructor parameter was null and throw exception.
+            //see https://github.com/rovo89/XposedBridge/blob/art/app/src/main/java/android/content/res/XResources.java
+            //i found it's super class is android.content.res.MiuiResources and MiuiResources's super class is android.content.res.Resources.
+            //maybe this is what we want.
+            if (TextUtils.equals(resourcesClass.getName(),"android.content.res.XResources")){
+                resourcesClass = resourcesClass.getSuperclass().getSuperclass();
+            }
             Constructor c = resourcesClass.getConstructor(
                     AssetManager.class, DisplayMetrics.class, Configuration.class);
             return (Resources) c.newInstance(assets, metrics, configuration);


### PR DESCRIPTION
try to fixed crash bug,when the phone install xposed.
when xposed is installed,context.getResource will return android.content.res.XResources,
it's constructor is here:
	/** Dummy, will never be called (objects are transferred to this class only). */
	private XResources() {
		super(null, null, null);
		throw new UnsupportedOperationException();
	}
and then i find it's supper class is MiuiResources ,it have same problem.
but MiuiResources's supper class is Resource,i think this will be work.

i don't think it's a perfect way to solve this problem。