### PR TITLE
Load from asset

### DIFF
--- a/Android/DevSample/build.gradle
+++ b/Android/DevSample/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.0.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -22,3 +22,6 @@ task clean(type: Delete) {
 }
 
 apply plugin: 'net.wequick.small'
+small {
+    buildToAssets = true
+}

--- a/Android/DevSample/buildSrc/src/main/groovy/net/wequick/gradle/BundlePlugin.groovy
+++ b/Android/DevSample/buildSrc/src/main/groovy/net/wequick/gradle/BundlePlugin.groovy
@@ -128,17 +128,21 @@ abstract class BundlePlugin extends AndroidPlugin {
         def appId = variant.applicationId
         if (appId == null) return null
 
-        def arch = System.properties['bundle.arch'] // Get from command line (-Dbundle.arch=xx)
-        if (arch == null) {
-            // Read from local.properties (bundle.arch=xx)
-            def prop = new Properties()
-            prop.load(project.rootProject.file('local.properties').newDataInputStream())
-            arch = prop.getProperty('bundle.arch')
-            if (arch == null) arch = 'armeabi' // Default
-        }
-        def so = "lib${appId.replaceAll('\\.', '_')}.so"
         RootExtension rootExt = project.rootProject.small
         def outputDir = rootExt.outputBundleDir
-        return new File(outputDir, "$arch/$so")
+        if (rootExt.buildToAssets) {
+            return new File(outputDir, "${appId}.apk")
+        } else {
+            def arch = System.properties['bundle.arch'] // Get from command line (-Dbundle.arch=xx)
+            if (arch == null) {
+                // Read from local.properties (bundle.arch=xx)
+                def prop = new Properties()
+                prop.load(project.rootProject.file('local.properties').newDataInputStream())
+                arch = prop.getProperty('bundle.arch')
+                if (arch == null) arch = 'armeabi' // Default
+            }
+            def so = "lib${appId.replaceAll('\\.', '_')}.so"
+            return new File(outputDir, "$arch/$so")
+        }
     }
 }

--- a/Android/DevSample/buildSrc/src/main/groovy/net/wequick/gradle/HostPlugin.groovy
+++ b/Android/DevSample/buildSrc/src/main/groovy/net/wequick/gradle/HostPlugin.groovy
@@ -14,11 +14,13 @@ class HostPlugin extends AndroidPlugin {
         
         project.afterEvaluate {
             // Configure libs dir
-            def jniDirs = project.android.sourceSets.main.jniLibs.srcDirs
-            if (jniDirs == null) {
-                project.android.sourceSets.main.jniLibs.srcDirs = [SMALL_LIBS]
+            RootExtension rootExt = project.rootProject.small
+            def sourceSet = project.android.sourceSets.main
+            def source = rootExt.buildToAssets ? sourceSet.assets : sourceSet.jniLibs
+            if (source.srcDirs == null) {
+                source.srcDirs = [SMALL_LIBS]
             } else {
-                project.android.sourceSets.main.jniLibs.srcDirs += SMALL_LIBS
+                source.srcDirs += SMALL_LIBS
             }
             // If contains release signing config, all bundles will be signed with it,
             // copy the config to debug type to ensure the signature-validating works

--- a/Android/DevSample/buildSrc/src/main/groovy/net/wequick/gradle/RootExtension.groovy
+++ b/Android/DevSample/buildSrc/src/main/groovy/net/wequick/gradle/RootExtension.groovy
@@ -42,6 +42,12 @@ public class RootExtension extends BaseExtension {
      */
     boolean strictSplitResources = true
 
+    /**
+     * If <tt>true</tt> build plugins to host assets as *.apk,
+     * otherwise build to host smallLibs as *.so
+     */
+    boolean buildToAssets = false
+
     /** Count of libraries */
     protected int libCount
 

--- a/Android/DevSample/gradle/wrapper/gradle-wrapper.properties
+++ b/Android/DevSample/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Dec 15 13:01:19 CST 2015
+#Thu May 05 17:19:39 CST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/Android/DevSample/small/src/main/java/net/wequick/small/Bundle.java
+++ b/Android/DevSample/small/src/main/java/net/wequick/small/Bundle.java
@@ -322,49 +322,43 @@ public class Bundle {
     }
 
     private void extractBundle(String assetName, File outFile) throws IOException {
-        if (!outFile.exists()) {
-            InputStream in = Small.getContext().getAssets().open(assetName);
-            FileOutputStream out = new FileOutputStream(outFile);
-            byte[] buffer = new byte[1024];
-            int read;
-            while ((read = in.read(buffer)) != -1) {
-                out.write(buffer, 0, read);
-            }
-            in.close();
-            out.flush();
-            out.close();
-        } else {
-            FileInputStream fin = new FileInputStream(outFile);
-            InputStream in = Small.getContext().getAssets().open(assetName);
-
+        InputStream in = Small.getContext().getAssets().open(assetName);
+        FileOutputStream out;
+        if (outFile.exists()) {
             // Compare the zip time to see if needs re-extract.
             // @see https://en.wikipedia.org/wiki/Zip_(file_format)
+            FileInputStream fin = new FileInputStream(outFile);
             final int headerSizeBeforeTime = 10;
             final int headerSizeOfTime = 4;
             byte[] inHeader = new byte[headerSizeBeforeTime];
             byte[] inTime = new byte[headerSizeOfTime];
             byte[] outTime = new byte[headerSizeOfTime];
-
             in.read(inHeader);
             in.read(inTime);
             fin.skip(headerSizeBeforeTime);
             fin.read(outTime);
             fin.close();
-            if (!Arrays.equals(inTime, outTime)) {
-                // The apk in assets has updated, re-extract it
-                FileOutputStream out = new FileOutputStream(outFile);
-                out.write(inHeader, 0, headerSizeBeforeTime);
-                out.write(inTime, 0, headerSizeOfTime);
-                byte[] buffer = new byte[1024];
-                int read;
-                while ((read = in.read(buffer)) != -1) {
-                    out.write(buffer, 0, read);
-                }
-                out.flush();
-                out.close();
+            if (Arrays.equals(inTime, outTime)) {
+                in.close();
+                return; // UP-TO-DATE
             }
-            in.close();
+
+            out = new FileOutputStream(outFile);
+            out.write(inHeader, 0, headerSizeBeforeTime);
+            out.write(inTime, 0, headerSizeOfTime);
+        } else {
+            out = new FileOutputStream(outFile);
         }
+
+        // Extract left data
+        byte[] buffer = new byte[1024];
+        int read;
+        while ((read = in.read(buffer)) != -1) {
+            out.write(buffer, 0, read);
+        }
+        out.flush();
+        out.close();
+        in.close();
     }
 
     private void initWithMap(JSONObject map) throws JSONException {

--- a/Android/DevSample/small/src/main/java/net/wequick/small/Bundle.java
+++ b/Android/DevSample/small/src/main/java/net/wequick/small/Bundle.java
@@ -32,6 +32,7 @@ import org.json.JSONObject;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FileReader;
@@ -40,6 +41,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -92,6 +94,7 @@ public class Bundle {
 
     private BundleLauncher mApplicableLauncher = null;
 
+    private String mBuiltinAssetName = null;
     private File mBuiltinFile = null;
     private File mPatchFile = null;
 
@@ -318,13 +321,71 @@ public class Bundle {
         mApplicableLauncher.upgradeBundle(this);
     }
 
+    private void extractBundle(String assetName, File outFile) throws IOException {
+        if (!outFile.exists()) {
+            InputStream in = Small.getContext().getAssets().open(assetName);
+            FileOutputStream out = new FileOutputStream(outFile);
+            byte[] buffer = new byte[1024];
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                out.write(buffer, 0, read);
+            }
+            in.close();
+            out.flush();
+            out.close();
+        } else {
+            FileInputStream fin = new FileInputStream(outFile);
+            InputStream in = Small.getContext().getAssets().open(assetName);
+
+            // Compare the zip time to see if needs re-extract.
+            // @see https://en.wikipedia.org/wiki/Zip_(file_format)
+            final int headerSizeBeforeTime = 10;
+            final int headerSizeOfTime = 4;
+            byte[] inHeader = new byte[headerSizeBeforeTime];
+            byte[] inTime = new byte[headerSizeOfTime];
+            byte[] outTime = new byte[headerSizeOfTime];
+
+            in.read(inHeader);
+            in.read(inTime);
+            fin.skip(headerSizeBeforeTime);
+            fin.read(outTime);
+            fin.close();
+            if (!Arrays.equals(inTime, outTime)) {
+                // The apk in assets has updated, re-extract it
+                FileOutputStream out = new FileOutputStream(outFile);
+                out.write(inHeader, 0, headerSizeBeforeTime);
+                out.write(inTime, 0, headerSizeOfTime);
+                byte[] buffer = new byte[1024];
+                int read;
+                while ((read = in.read(buffer)) != -1) {
+                    out.write(buffer, 0, read);
+                }
+                out.flush();
+                out.close();
+            }
+            in.close();
+        }
+    }
+
     private void initWithMap(JSONObject map) throws JSONException {
         String pkg = map.getString("pkg");
         if (pkg != null && !pkg.equals(HOST_PACKAGE)) {
-            String soName = "lib" + pkg.replaceAll("\\.", "_") + ".so";
-            mBuiltinFile = new File(sUserBundlesPath, soName);
-            mPatchFile = new File(FileUtils.getDownloadBundlePath(), soName);
             mPackageName = pkg;
+            if (Small.isLoadFromAssets()) {
+                mBuiltinAssetName = pkg + ".apk";
+                mBuiltinFile = new File(FileUtils.getInternalBundlePath(), mBuiltinAssetName);
+                mPatchFile = new File(FileUtils.getDownloadBundlePath(), mBuiltinAssetName);
+                // Extract from assets to files
+                try {
+                    extractBundle(mBuiltinAssetName, mBuiltinFile);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            } else {
+                String soName = "lib" + pkg.replaceAll("\\.", "_") + ".so";
+                mBuiltinFile = new File(sUserBundlesPath, soName);
+                mPatchFile = new File(FileUtils.getDownloadBundlePath(), soName);
+            }
         }
 
         if (map.has("uri")) {
@@ -485,6 +546,10 @@ public class Bundle {
 
     protected void setParser(BundleParser parser) {
         this.parser = parser;
+    }
+
+    public String getBuiltinAssetName() {
+        return mBuiltinAssetName;
     }
 
     //______________________________________________________________________________

--- a/Android/DevSample/small/src/main/java/net/wequick/small/Small.java
+++ b/Android/DevSample/small/src/main/java/net/wequick/small/Small.java
@@ -66,6 +66,16 @@ public final class Small {
     private static boolean sIsNewHostApp; // first launched or upgraded
     private static int sWebActivityTheme;
 
+    private static boolean sLoadFromAssets;
+
+    public static boolean isLoadFromAssets() {
+        return sLoadFromAssets;
+    }
+
+    public static void setLoadFromAssets(boolean flag) {
+        sLoadFromAssets = flag;
+    }
+
     public interface OnCompleteListener {
         void onComplete();
     }

--- a/Android/DevSample/small/src/main/java/net/wequick/small/util/FileUtils.java
+++ b/Android/DevSample/small/src/main/java/net/wequick/small/util/FileUtils.java
@@ -35,6 +35,7 @@ import java.util.zip.ZipInputStream;
  */
 public final class FileUtils {
     private static final String DOWNLOAD_PATH = "small_patch";
+    private static final String INTERNAL_PATH = "small_base";
 
     public interface OnProgressListener {
         void onProgress(int length);
@@ -100,5 +101,9 @@ public final class FileUtils {
 
     public static File getDownloadBundlePath() {
         return getInternalFilesPath(DOWNLOAD_PATH);
+    }
+
+    public static File getInternalBundlePath() {
+        return getInternalFilesPath(INTERNAL_PATH);
     }
 }

--- a/Android/Sample/app/src/main/java/net/wequick/example/small/Application.java
+++ b/Android/Sample/app/src/main/java/net/wequick/example/small/Application.java
@@ -12,6 +12,7 @@ public class Application extends android.app.Application {
 
         // Options
         Small.setBaseUri("http://m.wequick.net/demo/");
+        Small.setLoadFromAssets(true);
 
         // Required
         Small.preSetUp(this);


### PR DESCRIPTION
## [Feature] Loading bundles from host assets. 

This would allow the host to place multi-ABI (armeabi, x86 and etc) on the **lib** directory which may improve the performance on the related architecture device.

On the other side, the extracting from assets to storage would take more time on the initial launching.

### What we have done?

1. Compile-time
    * Build all the bundles and rename to `[bundle-package].apk`
    * Move the built APKs to host assets directory

2. Run-time
    * Extract APKs from assets to application internal storage
    * Load bundle dex and merge bundle assets from the extracted path

### How to introduce it?

1. Enable `buildToAssets` on your root `build.gradle`

    ```groovy
    small {
        buildToAssets = true
    }
    ```

2. Enable `loadFromAssets` on your application `onCreate`

    ```java
    Small.setLoadFromAssets(true);
    ```

3. Rebuild all the bundles and run the host