### PR TITLE
Fix the FileNotFoundException of 'local.properties'.

### DIFF
--- a/Android/DevSample/buildSrc/src/main/groovy/net/wequick/gradle/RootExtension.groovy
+++ b/Android/DevSample/buildSrc/src/main/groovy/net/wequick/gradle/RootExtension.groovy
@@ -242,8 +242,10 @@ public class RootExtension extends BaseExtension {
             if (arch == null) {
                 // Read from local.properties (bundle.arch=xx)
                 def prop = new Properties()
-                prop.load(project.rootProject.file('local.properties').newDataInputStream())
-                arch = prop.getProperty('bundle.arch')
+                if (project.rootProject.file('local.properties').exists()) {
+                    prop.load(project.rootProject.file('local.properties').newDataInputStream())
+                    arch = prop.getProperty('bundle.arch')
+                }
                 if (arch == null) arch = 'armeabi' // Default
             }
             def so = "lib${bundleId.replaceAll('\\.', '_')}.so"


### PR DESCRIPTION
------
Building with 'buildBundle' crashed if my project has no local.properties file.
Here offers some light codes to fix this case, that checks null always.
------
Signed-off-by: zhaoya_sx <zhaoya_sx@qiyi.com>