### PR TITLE
Add order field to bundle.json to set 'so' load sequence

### DIFF
--- a/Android/DevSample/small/src/main/java/net/wequick/small/Bundle.java
+++ b/Android/DevSample/small/src/main/java/net/wequick/small/Bundle.java
@@ -100,6 +100,8 @@ public class Bundle {
     private Intent mIntent;
     private String type;
     private String path;
+    //Launch application order.
+    private int order;
     private String query;
     private HashMap<String, String> rules;
     private int versionCode;
@@ -527,6 +529,12 @@ public class Bundle {
             this.type = map.getString("type");
         }
 
+        if (map.has("order")) {
+            this.order = Integer.parseInt(map.getString("order"));
+        } else {
+            //Default means don't care the order, so put it at last.
+            this.order = Integer.MAX_VALUE;
+        }
         this.rules = new HashMap<String, String>();
         String entrancePath = DEFAULT_ENTRANCE_PATH;
         if (map.has("rules")) {
@@ -589,6 +597,10 @@ public class Bundle {
 
     protected Uri getUri() {
         return uri;
+    }
+
+    protected int getOrder() {
+        return order;
     }
 
     protected void setURL(URL url) {


### PR DESCRIPTION
{
      "uri": "main",
      "order": 1,
      "pkg": "net.wequick.example.small.app.main"
},
{
      "uri": "detail",
      "pkg": "net.wequick.example.small.app.detail",
      "order": 2,
      "rules": {
        "sub": "Sub"
      }
},
{
      "uri": "mine",
      "order": 2,
      "pkg": "net.wequick.example.small.app.mine"
},
{
      "uri": "about",
      "order": 3,
      "pkg": "net.wequick.example.small.web.about"
}

If your 'so' need to set load sequence, then set value to order in bundle.json. eg:
app.main ->app.detail -> app.mine - > app.about